### PR TITLE
feat(train): wire frame WebDataset shards into Phase-1/2 training

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -15,7 +15,9 @@ model:
 
   # Flags
   use_mqot: false # Default: Disabled
-  use_backbones: false # Default: Feature-based (Offline backbones)
+  use_backbones: false # Visual ResNet on raw frames; set true for WebDataset frame shards
+  use_audio_backbone: false # Whisper on RAW audio; off — shards store precomputed Whisper feats
+  visual_pretrained: true # ResNet18 ImageNet weights; false = from-scratch / offline tests
 
 loss:
   ctc_weight: 0.3

--- a/configs/phase1_base.yaml
+++ b/configs/phase1_base.yaml
@@ -1,15 +1,21 @@
-# Phase 1 Configuration (Inherits from base.yaml)
+# Phase 1 — QualityGate-only baseline (use_mqot=false) on the WebDataset FRAME shards.
+# Inherits base.yaml; overrides data → webdataset frame shards, and turns the visual backbone on.
 defaults:
   - base
+
+model:
+  use_backbones: true # frame shards yield raw frames [T,C,H,W] → ResNet runs at train time
 
 loss:
   ctc_weight: 0.5
   ce_weight: 0.5
 
+data:
+  format: webdataset
+  train_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-*.tar"
+  val_shards: "/mnt/vicocktail_features/vicocktail-avvn-test-000000-*.tar" # clean test (process test sets first)
+  batch_size: 16
+  shuffle_buffer: 2000
+
 logging:
   checkpoint_dir: "/mnt/checkpoints/phase1"
-
-data:
-  train_manifest: "/mnt/vicocktail_features/avvn-test_snr_0_interferer_1-000000_manifest.jsonl"
-  val_manifest: "/mnt/vicocktail_features/avvn-val_manifest.jsonl"
-  data_root: "/mnt/vicocktail_features/avvn-test_snr_0_interferer_1-000000"

--- a/configs/phase1_frames_trial.yaml
+++ b/configs/phase1_frames_trial.yaml
@@ -1,0 +1,17 @@
+# Smoke config — validate the FRAME-shard training path end-to-end on Modal (cheap).
+# Inherits phase1_base (webdataset + use_backbones); shrinks to 1 shard / few samples / 1 epoch.
+# Isolated checkpoint_dir so we DON'T touch the team's checkpoints/phase1.
+defaults:
+  - phase1_base
+
+data:
+  train_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-000000-*.tar"
+  val_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-000000-*.tar" # test set not processed yet → reuse a train shard
+  max_samples: 48
+  batch_size: 4
+
+training:
+  num_epochs: 1
+
+logging:
+  checkpoint_dir: "/mnt/checkpoints/phase1_frames_trial"

--- a/configs/phase2_frames_trial.yaml
+++ b/configs/phase2_frames_trial.yaml
@@ -1,0 +1,19 @@
+# Smoke config — validate the FRAME-shard + MQOT path end-to-end on Modal (cheap).
+# Inherits phase2_mqot (use_mqot + mqot params, which inherits phase1_base → webdataset+backbones).
+# Shrinks to 1 shard / few samples / 1 epoch; pretrained_path → the phase1_frames_trial checkpoint
+# (strict=False: MQOT params init fresh), mirroring the real phase1 → phase2 warm-start.
+defaults:
+  - phase2_mqot
+
+data:
+  train_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-000000-*.tar"
+  val_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-000000-*.tar"
+  max_samples: 48
+  batch_size: 2
+
+training:
+  num_epochs: 1
+  pretrained_path: "/mnt/checkpoints/phase1_frames_trial/best_model.pt"
+
+logging:
+  checkpoint_dir: "/mnt/checkpoints/phase2_frames_trial"

--- a/configs/phase2_mqot.yaml
+++ b/configs/phase2_mqot.yaml
@@ -17,7 +17,7 @@ loss:
   quality_loss_weight: 0.1
 
 data:
-  batch_size: 24 # Reduced for OT Memory
+  batch_size: 12 # Reduced for OT memory + raw frames (heavier than precomputed features)
 
 training:
   learning_rate: 5e-5 # Fine-tuning LR

--- a/scripts/modal/train_phase1.py
+++ b/scripts/modal/train_phase1.py
@@ -38,13 +38,18 @@ def train_remote(manifest_path: str = None, config_path: str = None):
     final_manifest = manifest_path if manifest_path else MANIFEST_PATH
     final_config_path = config_path if config_path else "/root/configs/phase1_base.yaml"
 
-    if not os.path.exists(final_manifest):
-        logger.error(f"Manifest {final_manifest} not found. Run preprocessing first.")
-        # Debug list dir if default
+    # Load config first so we can detect the data format.
+    config = load_config(final_config_path)
+
+    # WebDataset (frame shards): no jsonl manifest — data.train_shards/val_shards drive the loader.
+    if str(config.get("data", {}).get("format", "")).lower() == "webdataset":
+        logger.info(f"Loaded config from {final_config_path} (format=webdataset)")
+        run_training(config)
         return
 
-    # Load Config from YAML (with inheritance)
-    config = load_config(final_config_path)
+    if not os.path.exists(final_manifest):
+        logger.error(f"Manifest {final_manifest} not found. Run preprocessing first.")
+        return
     
     # Override manifest in config if provided override differs
     if manifest_path:

--- a/scripts/modal/train_phase2.py
+++ b/scripts/modal/train_phase2.py
@@ -21,18 +21,20 @@ volume = get_volume()
     gpu="A10G",
     timeout=7200
 )
-def train_remote():
+def train_remote(config_path: str = None):
     # THIN Modal wrapper: set up container paths, then call the pure training logic
     # (src/training/run.py).
     sys.path.append("/root")
     from src.utils.config_utils import load_config
     from src.training.run import run_training
 
-    # Load config (inheritance). use_mqot=True lives in phase2_mqot.yaml.
-    config = load_config("/root/configs/phase2_mqot.yaml")
-    # run_training validates the manifest in config + selects device (cuda on Modal GPU).
+    # Load config (inheritance). use_mqot=True lives in phase2_mqot.yaml; pass --config-path
+    # /root/configs/phase2_frames_trial.yaml for the frame-shard smoke.
+    final_config_path = config_path if config_path else "/root/configs/phase2_mqot.yaml"
+    config = load_config(final_config_path)
+    # run_training selects device (cuda on Modal GPU); the webdataset path needs no manifest.
     run_training(config)
 
 @app.local_entrypoint()
-def main():
-    train_remote.remote()
+def main(config_path: str = None):
+    train_remote.remote(config_path=config_path)

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -133,6 +133,11 @@ def _build_webdataset_loader(config: Dict, data_cfg: Dict, tokenizer, mode: str)
         shuffle_buffer=data_cfg.get("shuffle_buffer", 1000),
     )
 
+    # Cheap smoke runs: cap the stream to N samples. Real training leaves this unset (unbounded).
+    max_samples = data_cfg.get("max_samples")
+    if max_samples:
+        dataset = dataset.slice(int(max_samples))
+
     pad_id = getattr(tokenizer, "eot_token_id", 50257)
     return DataLoader(
         dataset,

--- a/src/data/shards.py
+++ b/src/data/shards.py
@@ -140,6 +140,16 @@ def build_webdataset(
             "rel_path": sample["__key__"],
         }
 
+    # webdataset expands brace patterns ("{000..099}") but NOT shell globs ("*"); a "*" pattern
+    # would be passed through as a literal (missing) filename → silently 0 samples. Expand it here
+    # and fail loud on no match (never silently train on an empty stream).
+    if isinstance(shards, str) and "*" in shards:
+        import glob
+        matched = sorted(glob.glob(shards))
+        if not matched:
+            raise FileNotFoundError(f"No shards matched glob pattern: {shards}")
+        shards = matched
+
     ds = wds.WebDataset(shards, shardshuffle=train, handler=wds.warn_and_continue)
     if train and shuffle_buffer > 0:
         ds = ds.shuffle(shuffle_buffer)

--- a/src/infra/modal_image.py
+++ b/src/infra/modal_image.py
@@ -66,6 +66,7 @@ ML_TRAIN_IMAGE = (
         "matplotlib",
         "soundfile",
         "opencv-python-headless",
+        "webdataset==0.2.79",  # training reads frame WebDataset shards (src/data/shards.py)
         # Re-pin numpy<2: this separate layer re-resolves deps and would otherwise
         # upgrade numpy to 2.x, breaking torch 2.1.2's ABI (compiled against numpy 1.x).
         "numpy<2",

--- a/src/models/mota.py
+++ b/src/models/mota.py
@@ -1,7 +1,7 @@
 """
 Architecture:
-- Audio: Whisper encoder (frozen/finetune) -> 768
-- Visual: ResNet18 (frozen/finetune) -> 512
+- Audio: precomputed Whisper features -> 768 (raw-audio Whisper backbone optional, OFF by default)
+- Visual: raw mouth-crop frames -> ResNet18 (use_backbones) -> 512, or precomputed features
 - Fusion Stage 1: Quality gating (Coarse)
 - Fusion Stage 2: M-QOT + Guided Attention (Fine/Optional)
 - Encoder: Conformer
@@ -53,21 +53,30 @@ class MOTA(nn.Module):
         
         # Toggle Flags
         self.use_mqot = config.get('use_mqot', False)
+        # use_backbones → run the VISUAL ResNet on raw frames at train time (frame-shard pipeline).
+        # use_audio_backbone → run Whisper on RAW audio; OFF by default since the shards already
+        # store precomputed Whisper features (the model reads them directly).
         self.use_backbones = config.get('use_backbones', False)
+        self.use_audio_backbone = config.get('use_audio_backbone', False)
         
         # ============================================================
-        # STAGE 0: OPTIONAL BACKBONES (E2E Readiness)
+        # STAGE 0: OPTIONAL BACKBONES (raw → features at train time)
         # ============================================================
+        # Visual ResNet: needed when the dataset yields raw frames [B,T,C,H,W] (WebDataset frame
+        # shards). Frozen by default (Section A); per-epoch frame augmentation is upstream in the loader.
         if self.use_backbones:
-            # Audio: Whisper
-            self.whisper = WhisperModel.from_pretrained("openai/whisper-tiny")
-            self.whisper.encoder.requires_grad_(False) # Default Frozen
-            
-            # Visual: ResNet18
-            resnet = resnet18(weights=ResNet18_Weights.DEFAULT)
-            # Remove FC and AvgPool to get spatial/temporal features
-            self.visual_backbone = nn.Sequential(*list(resnet.children())[:-2]) 
-            self.visual_backbone.requires_grad_(False) # Default Frozen
+            # visual_pretrained=False → no ImageNet download (offline tests / from-scratch ablation).
+            visual_weights = ResNet18_Weights.DEFAULT if config.get('visual_pretrained', True) else None
+            resnet = resnet18(weights=visual_weights)
+            # Strip FC + AvgPool → spatial feature map; pooled per-frame in forward_backbones.
+            self.visual_backbone = nn.Sequential(*list(resnet.children())[:-2])
+            self.visual_backbone.requires_grad_(False)  # frozen; Section C: gate on train_visual_backbone
+
+        # Audio Whisper backbone: ONLY for true raw-audio E2E. Off by default — the shards store
+        # precomputed Whisper features, so loading Whisper here otherwise = dead weight.
+        if self.use_audio_backbone:
+            self.whisper = WhisperModel.from_pretrained("openai/whisper-small")
+            self.whisper.encoder.requires_grad_(False)
             
         # ============================================================
         # STAGE 1: COARSE FUSION (QualityGate - Baseline)
@@ -153,7 +162,8 @@ class MOTA(nn.Module):
             # Flatten time: [B*T, C, H, W]
             visual_flat = visual.view(B * T, C, H, W)
             
-            # Forward ResNet (Frozen)
+            # Forward ResNet. Frozen for Section A; for Section C E2E this no_grad must become
+            # conditional on a train_visual_backbone flag. TODO(Section C).
             with torch.no_grad():
                 # self.visual_backbone outputs [B*T, 512, H', W']
                 feat_map = self.visual_backbone(visual_flat)
@@ -168,9 +178,8 @@ class MOTA(nn.Module):
             # Reshape back: [B, T, 512]
             visual = feat.view(B, T, -1)
 
-        # Audio: [B, Samples] or [B, T, 768]
-        # Current GridDataset returns [B, T, 768] even in raw mode (AudioFeatureExtractor)
-        # So we pass through.
+        # Audio: datasets/shards already yield precomputed Whisper features [B, T_a, 768], so we
+        # pass through. (If use_audio_backbone is ever wired for raw waveforms, run self.whisper here.)
         
         return audio, visual
 

--- a/src/training/run.py
+++ b/src/training/run.py
@@ -25,12 +25,16 @@ def run_training(config: Dict) -> Trainer:
     Returns:
         Trainer sau khi train xong (tiện cho test/inspection).
     """
+    data_format = str(config["data"].get("format", "jsonl")).lower()
     train_manifest = config["data"].get("train_manifest")
-    if train_manifest and not os.path.exists(train_manifest):
+    # WebDataset (frame shards) reads data.train_shards/val_shards — there is no jsonl manifest,
+    # so skip the manifest existence check (train_manifest may still be inherited from base.yaml).
+    if data_format != "webdataset" and train_manifest and not os.path.exists(train_manifest):
         logger.error(f"Train manifest không tồn tại: {train_manifest}")
         raise FileNotFoundError(train_manifest)
 
-    logger.info(f"Device-agnostic training | manifest={train_manifest}")
+    source = config["data"].get("train_shards") if data_format == "webdataset" else train_manifest
+    logger.info(f"Device-agnostic training | format={data_format} | source={source}")
     trainer = Trainer(config)
     trainer.train()
     return trainer

--- a/tests/unit/test_model_frames.py
+++ b/tests/unit/test_model_frames.py
@@ -1,0 +1,73 @@
+"""Model forward tests for the frame-shard path (visual backbone runs at train time).
+
+The frame WebDataset pipeline stores raw mouth-crop frames [T,C,H,W] for visual and
+precomputed Whisper features [T_a,768] for audio. So the model must:
+  - run the visual ResNet on 5D frame input when ``use_backbones`` is set, and
+  - NOT load a Whisper audio backbone (audio is already features) unless
+    ``use_audio_backbone`` is explicitly set.
+
+These build the model with ``visual_pretrained=False`` so no ImageNet weights are fetched
+(offline / CI-safe) — we only check wiring + shapes + gradient flow on synthetic tensors.
+"""
+import torch
+
+from src.models.mota import create_model
+
+VOCAB = 100
+
+
+def _cfg(**over):
+    cfg = dict(
+        audio_dim=768,
+        visual_dim=512,
+        d_model=64,
+        num_encoder_layers=1,
+        num_decoder_layers=1,
+        num_heads=4,
+        vocab_size=VOCAB,
+        dropout=0.0,
+        use_mqot=False,
+        use_backbones=True,        # visual ResNet on raw frames
+        use_audio_backbone=False,  # audio already = Whisper features → no Whisper load
+        visual_pretrained=False,   # offline-safe (no ImageNet download in tests)
+    )
+    cfg.update(over)
+    return cfg
+
+
+def test_frame_mode_forward_backward_and_no_audio_backbone():
+    """use_backbones loads ONLY the visual ResNet; Whisper must NOT be loaded."""
+    torch.manual_seed(0)
+    model = create_model(_cfg())
+
+    assert hasattr(model, "visual_backbone"), "use_backbones=True must load the visual ResNet"
+    assert not hasattr(model, "whisper"), "use_audio_backbone=False must NOT load Whisper"
+
+    B, Ta, Tv, L = 2, 12, 6, 5
+    audio = torch.randn(B, Ta, 768)               # precomputed Whisper feats
+    visual = torch.rand(B, Tv, 3, 88, 88)         # raw mouth-crop frames [0,1]
+    target = torch.randint(0, VOCAB, (B, L))
+
+    out = model(audio, visual, target)
+    assert out["ctc_logits"].shape == (B, Ta, VOCAB)
+    assert out["ar_logits"].shape == (B, L, VOCAB)
+
+    (out["ctc_logits"].sum() + out["ar_logits"].sum()).backward()
+    assert model.audio_proj.weight.grad is not None
+    assert model.visual_proj.weight.grad is not None
+
+
+def test_feature_mode_still_works():
+    """Regression: the precomputed-feature path (no backbones) is unchanged."""
+    torch.manual_seed(0)
+    model = create_model(_cfg(use_backbones=False))
+
+    assert not hasattr(model, "visual_backbone")
+    assert not hasattr(model, "whisper")
+
+    B, Ta, Tv = 2, 12, 6
+    audio = torch.randn(B, Ta, 768)
+    visual = torch.randn(B, Tv, 512)              # precomputed ResNet features
+    out = model(audio, visual)
+    assert out["ctc_logits"].shape == (B, Ta, VOCAB)
+    assert out["ar_logits"] is None               # no target → no AR logits

--- a/tests/unit/test_webdataset.py
+++ b/tests/unit/test_webdataset.py
@@ -4,6 +4,7 @@ Writes synthetic samples (uint8 mouth-crop frames + fp16 Whisper audio features)
 shards, then reads them back through the streaming reader and asserts the decoded dict
 matches what the Collator/model expect. No network, no heavy deps — synthetic tensors.
 """
+import pytest
 import torch
 
 from src.data.shards import write_feature_shards, build_webdataset
@@ -98,3 +99,27 @@ def test_val_order_is_deterministic(tmp_path):
     order1 = [s["rel_path"] for s in build_webdataset(shards, _FakeTokenizer(), train=False)]
     order2 = [s["rel_path"] for s in build_webdataset(shards, _FakeTokenizer(), train=False)]
     assert order1 == order2 == [f"sample{i:04d}" for i in range(6)]
+
+
+def test_slice_caps_sample_count(tmp_path):
+    """dataset.slice(n) caps the stream — backs the loader's max_samples for cheap smoke runs."""
+    pattern = str(tmp_path / "s-%06d.tar")
+    write_feature_shards(_samples(10), pattern, maxcount=4)
+    shards = sorted(str(p) for p in tmp_path.glob("s-*.tar"))
+
+    ds = build_webdataset(shards, _FakeTokenizer(), train=False).slice(3)
+    assert len(list(ds)) == 3
+
+
+def test_glob_pattern_expands_to_shards(tmp_path):
+    """A '*' glob string must expand to matching shards (webdataset only does brace expansion)."""
+    pattern = str(tmp_path / "g-%06d.tar")
+    write_feature_shards(_samples(6), pattern, maxcount=2)  # → 3 shards
+    ds = build_webdataset(str(tmp_path / "g-*.tar"), _FakeTokenizer(), train=False)
+    assert len(list(ds)) == 6
+
+
+def test_empty_glob_raises_not_silent(tmp_path):
+    """A glob matching nothing must raise — never silently train on 0 samples."""
+    with pytest.raises(FileNotFoundError):
+        build_webdataset(str(tmp_path / "nomatch-*.tar"), _FakeTokenizer(), train=False)


### PR DESCRIPTION
Preprocessing now emits raw mouth-crop FRAMES + precomputed Whisper features in WebDataset shards, but training still assumed the old .pt/manifest pipeline. This wires the frame shards in and fixes the integration gaps found in review, verified by Modal smoke runs of both phases (loss finite, checkpoints saved).

Model (mota.py):
- Split use_backbones (visual ResNet on raw frames) from a new use_audio_backbone (Whisper, default OFF) — shards already store Whisper features, so the in-model Whisper was dead weight (and was whisper-tiny vs the pipeline's whisper-small).
- Add visual_pretrained flag (offline tests / from-scratch ablation).

Data:
- shards.py: expand "*" globs (webdataset only does brace patterns) and RAISE on no match — never silently train on 0 samples.
- loader.py: honor max_samples for webdataset (cheap smoke runs).

Training:
- run.py + train_phase1/2: skip the jsonl manifest guard when data.format=webdataset; train scripts accept --config-path.
- modal_image.py: add webdataset to ML_TRAIN_IMAGE.

Configs:
- phase1_base/phase2_mqot -> webdataset frame shards + use_backbones=true.
- new phase1_frames_trial / phase2_frames_trial smoke configs.

Tests: +3 (frame-mode forward/backward + no-Whisper; glob expand; empty-glob raises). 24 pass, ruff clean. Smoke: phase2 warm-starts from phase1 (strict=False, 40 MQOT keys fresh).