### PR TITLE
perf(train): ~2x faster data loading + epoch progress bar + 24h timeout

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -36,8 +36,11 @@ data:
 
   batch_size: 32
   num_workers: 2
+  prefetch_factor: 4 # batches prefetched per worker (smoother GPU feed; applied only when num_workers>0)
+  persistent_workers: true # keep dataloader workers alive across epochs (avoid respawn cost)
   use_precomputed_features: true
   max_samples: null
+  samples_per_epoch: null # approx clips/epoch → train progress-bar total (tqdm); null = bare "Nit" count
 
 training:
   seed: 42

--- a/configs/phase1.yaml
+++ b/configs/phase1.yaml
@@ -18,7 +18,9 @@ data:
   train_shards: "/mnt/vicocktail_features/vicocktail-avvn-train-*.tar"
   val_shards: "/mnt/vicocktail_features/vicocktail-avvn-test-000000-*.tar" # clean test (process test sets first)
   batch_size: 16
-  shuffle_buffer: 2000
+  num_workers: 4 # 2→4: more parallel frame decode — GPU was data-bound (59% util on A10G)
+  shuffle_buffer: 1000 # halved so RAM stays ~same with 2× workers (4×1000 ≈ 2×2000 buffered)
+  samples_per_epoch: 194073 # ViCocktail train clips (≈ sum of shard _meta.json) → progress-bar total
 
 logging:
   use_wandb: true

--- a/scripts/modal/train_phase1.py
+++ b/scripts/modal/train_phase1.py
@@ -22,7 +22,9 @@ volume = get_volume()
     image=ML_TRAIN_IMAGE,
     volumes={"/mnt": volume},
     gpu="A10G",         # A10G is good balance
-    timeout=21600,      # 6h — headroom for a full-data calibration epoch (was 2h, too tight)
+    cpu=8.0,            # dedicated cores for num_workers=4 frame decode (was data-bound @59% GPU util)
+    memory=40960,       # 40GB for per-worker shuffle buffers (num_workers × shuffle_buffer)
+    timeout=86400,      # 24h (Modal max) — fits ~14 epochs/container → far fewer manual relaunches
     secrets=[modal.Secret.from_name("wandb")],  # WANDB_API_KEY (create: modal secret create wandb WANDB_API_KEY=...)
 )
 def train_remote(manifest_path: str = None, config_path: str = None):

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -139,13 +139,17 @@ def _build_webdataset_loader(config: Dict, data_cfg: Dict, tokenizer, mode: str)
         dataset = dataset.slice(int(max_samples))
 
     pad_id = getattr(tokenizer, "eot_token_id", 50257)
-    return DataLoader(
-        dataset,
+    loader_kwargs = dict(
         batch_size=data_cfg.get("batch_size", 32),
         num_workers=data_cfg.get("num_workers", 2),
         collate_fn=Collator(pad_id),
         pin_memory=torch.cuda.is_available(),
     )
+    # prefetch_factor / persistent_workers are only valid with worker processes (num_workers > 0)
+    if loader_kwargs["num_workers"] > 0:
+        loader_kwargs["prefetch_factor"] = data_cfg.get("prefetch_factor", 4)
+        loader_kwargs["persistent_workers"] = data_cfg.get("persistent_workers", True)
+    return DataLoader(dataset, **loader_kwargs)
 
 
 def _detect_dataset_type(manifest_path: str) -> str:

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -135,6 +135,10 @@ class Trainer:
         self.best_metric = float('inf')
         self.log_interval = config['logging'].get('log_interval', 50)  # wandb per-step cadence
         self.train_wer_interval = config['logging'].get('train_wer_interval', 500)  # periodic train WER (0=off)
+        # Progress-bar total: WebDataset is an IterableDataset (no __len__), so derive steps/epoch
+        # from the known clip count → tqdm shows "210/12129 [ETA]" instead of a bare "210it".
+        _spe = config['data'].get('samples_per_epoch')
+        self.train_steps = (_spe // config['data']['batch_size']) if _spe else None
 
         # Load Pretrained / Resume.
         # True resume (full state) takes precedence over pretrained (weights-only warm-start):
@@ -304,7 +308,7 @@ class Trainer:
         # 0.9.5 Fix: Ensure gradients are zeroed before loop starts
         self.optimizer.zero_grad()
         
-        pbar = tqdm(self.train_loader, desc=f"Train E{epoch}")
+        pbar = tqdm(self.train_loader, desc=f"Train E{epoch}", total=self.train_steps)
         grad_norm = 0.0  # Always defined for consistent tqdm postfix
         for batch_idx, batch in enumerate(pbar):
             if batch is None:   # cả batch hỏng (mọi sample lỗi load) → skip


### PR DESCRIPTION
GPU was data-bound (~59% util) on A10G: the frozen-ResNet path decodes raw frames on CPU and couldn't feed the GPU. Parallelize decode — num_workers 2->4, prefetch_factor 4, persistent_workers, cpu/mem reserve (shuffle_buffer 2000->1000 to keep RAM ~flat). Observed ~1.0 -> ~2.0 it/s.

Also: webdataset is an IterableDataset (no __len__) so tqdm showed a bare 'Nit' count — add samples_per_epoch (194073 ViCocktail train clips) -> 'N/12129 [ETA]'. Bump Modal timeout 6h->24h (6h fit only ~3.5 epochs -> frequent relaunches).

All changes are dataloader/infra/logging only — checkpoints untouched, resume unaffected. 38 unit tests pass.